### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/secret-scanning-check.yml
+++ b/.github/workflows/secret-scanning-check.yml
@@ -4,7 +4,10 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, reopened]
-    
+
+permissions:
+  contents: read
+
 jobs:
   Secret-Scanning-Check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/appatalks/Epassafe/security/code-scanning/1](https://github.com/appatalks/Epassafe/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to read repository contents (e.g., fetching secret scanning alerts), we will set `contents: read` as the minimal required permission. This ensures that the `GITHUB_TOKEN` has the least privilege necessary to perform the workflow's tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
